### PR TITLE
do nothing when the pointcloud is empty

### DIFF
--- a/pcl_apps/src/filter/radius_outlier_removal/radius_outlier_removal_component.cpp
+++ b/pcl_apps/src/filter/radius_outlier_removal/radius_outlier_removal_component.cpp
@@ -71,12 +71,14 @@ RadiusOutlierRemovalComponent::RadiusOutlierRemovalComponent(const rclcpp::NodeO
   auto callback = [this](const typename sensor_msgs::msg::PointCloud2::SharedPtr msg) -> void {
       pcl::PointCloud<pcl::PointXYZI>::Ptr cloud(new pcl::PointCloud<pcl::PointXYZI>);
       pcl::fromROSMsg(*msg, *cloud);
-      filter_.setInputCloud(cloud);
-      filter_.setRadiusSearch(search_radius_);
-      filter_.setMinNeighborsInRadius(min_neighbors_in_search_radius_);
-      pcl::PointCloud<pcl::PointXYZI>::Ptr cloud_filtered(new pcl::PointCloud<pcl::PointXYZI>);
-      filter_.filter(*cloud_filtered);
-      pcl::toROSMsg(*cloud_filtered, *msg);
+      if (cloud->size() != 0) {
+        filter_.setInputCloud(cloud);
+        filter_.setRadiusSearch(search_radius_);
+        filter_.setMinNeighborsInRadius(min_neighbors_in_search_radius_);
+        pcl::PointCloud<pcl::PointXYZI>::Ptr cloud_filtered(new pcl::PointCloud<pcl::PointXYZI>);
+        filter_.filter(*cloud_filtered);
+        pcl::toROSMsg(*cloud_filtered, *msg);
+      }
       pub_->publish(*msg);
     };
   sub_ = create_subscription<sensor_msgs::msg::PointCloud2>(input_topic_, 10, callback);


### PR DESCRIPTION
Signed-off-by: Masaya Kataoka <ms.kataoka@gmail.com>

do nothing when the pointcloud is empty and remove warning from radius_outlier_removal node